### PR TITLE
create vault clients

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,9 +11,11 @@ var (
 		Use:   "certificate-sidekick",
 		Short: "A sidekick process able to request certificate generation from Vault to write files to the local filesystem.",
 
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.HelpFunc()(cmd, nil)
-			os.Exit(1)
-		},
+		Run: cliRun,
 	}
 )
+
+func cliRun(cmd *cobra.Command, args []string) {
+	cmd.HelpFunc()(cmd, nil)
+	os.Exit(1)
+}

--- a/cli/error.go
+++ b/cli/error.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)
+
+func maskAnyf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	generateCmd = &cobra.Command{
+		Use:   "generate",
+		Short: "Generate certificates.",
+		Run:   generateRun,
+	}
+)
+
+func init() {
+	CLICmd.AddCommand(generateCmd)
+}
+
+func generateRun(cmd *cobra.Command, args []string) {
+	cmd.HelpFunc()(cmd, nil)
+	os.Exit(1)
+}

--- a/cli/generate_ca.go
+++ b/cli/generate_ca.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/certificate-sidekick/service/vault-factory"
+)
+
+var (
+	generateCACmd = &cobra.Command{
+		Use:   "ca",
+		Short: "Generate a certificate authority.",
+		Run:   generateCARun,
+	}
+
+	generateCAVaultAddress string
+	generateCAVaultToken   string
+)
+
+func init() {
+	generateCmd.AddCommand(generateCACmd)
+
+	generateCACmd.Flags().StringVar(&generateCAVaultAddress, "vault-address", "http://127.0.0.1:8200", "Address used to connect to Vault.")
+	generateCACmd.Flags().StringVar(&generateCAVaultToken, "vault-token", "", "Token used to authenticate against Vault.")
+}
+
+func generateCARun(cmd *cobra.Command, args []string) {
+	if generateCAVaultToken == "" {
+		log.Fatalf("%#v\n", maskAnyf(invalidConfigError, "Vault token must not be empty"))
+	}
+
+	// Create Vault client and configure it with the provided admin token.
+	newVaultConfig := vaultfactory.DefaultConfig()
+	newVaultConfig.HTTPClient = &http.Client{}
+	newVaultConfig.Address = generateCAVaultAddress
+	newVaultConfig.AdminToken = generateCAVaultToken
+	newVault, err := vaultfactory.New(newVaultConfig)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	fmt.Printf("%#v\n", newVault)
+
+	// TODO
+}

--- a/cli/generate_signed.go
+++ b/cli/generate_signed.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/certificate-sidekick/service/vault-factory"
+)
+
+var (
+	generateSignedCmd = &cobra.Command{
+		Use:   "signed",
+		Short: "Generate signed certificates.",
+		Run:   generateSignedRun,
+	}
+
+	generateSignedVaultAddress string
+	generateSignedVaultToken   string
+)
+
+func init() {
+	generateCmd.AddCommand(generateSignedCmd)
+
+	generateSignedCmd.Flags().StringVar(&generateSignedVaultAddress, "vault-address", "http://127.0.0.1:8200", "Address used to connect to Vault.")
+	generateSignedCmd.Flags().StringVar(&generateSignedVaultToken, "vault-token", "", "Token used to authenticate against Vault.")
+}
+
+func generateSignedRun(cmd *cobra.Command, args []string) {
+	if generateSignedVaultToken == "" {
+		log.Fatalf("%#v\n", maskAnyf(invalidConfigError, "Vault token must not be empty"))
+	}
+
+	// Create Vault client and configure it with the provided admin token.
+	newVaultConfig := vaultfactory.DefaultConfig()
+	newVaultConfig.HTTPClient = &http.Client{}
+	newVaultConfig.Address = generateSignedVaultAddress
+	newVaultConfig.AdminToken = generateSignedVaultToken
+	newVault, err := vaultfactory.New(newVaultConfig)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	fmt.Printf("%#v\n", newVault)
+
+	// TODO
+}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)

--- a/main.go
+++ b/main.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/giantswarm/certificate-sidekick/cli"
 )
 
 func main() {
 	if err := cli.CLICmd.Execute(); err != nil {
-		log.Print(err)
-		os.Exit(1)
+		log.Fatalf("%#v\n", maskAny(err))
 	}
 }

--- a/service/spec/vault_factory.go
+++ b/service/spec/vault_factory.go
@@ -1,0 +1,11 @@
+package spec
+
+import (
+	vault "github.com/hashicorp/vault/api"
+)
+
+// VaultFactory implements a factory that is able to create Vault clients.
+type VaultFactory interface {
+	// NewClient creates a new Vault client configured with an admin token.
+	NewClient() (*vault.Client, error)
+}

--- a/service/vault-factory/error.go
+++ b/service/vault-factory/error.go
@@ -1,0 +1,30 @@
+package vaultfactory
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)
+
+func maskAnyf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/vault-factory/vault_factory.go
+++ b/service/vault-factory/vault_factory.go
@@ -1,0 +1,71 @@
+package vaultfactory
+
+import (
+	"net/http"
+
+	vaultclient "github.com/hashicorp/vault/api"
+
+	"github.com/giantswarm/certificate-sidekick/service/spec"
+)
+
+// Config represents the configuration used to create a new Vault factory.
+type Config struct {
+	// Dependencies.
+	HTTPClient *http.Client
+
+	// Settings.
+	Address    string
+	AdminToken string
+}
+
+// DefaultConfig provides a default configuration to create a Vault factory.
+func DefaultConfig() Config {
+	newConfig := Config{
+		// Dependencies.
+		HTTPClient: http.DefaultClient,
+
+		// Settings.
+		Address:    "http://127.0.0.1:8200",
+		AdminToken: "admin-token",
+	}
+
+	return newConfig
+}
+
+// New creates a new configured Vault factory.
+func New(config Config) (spec.VaultFactory, error) {
+	newSecret := &vault{
+		Config: config,
+	}
+
+	// Dependencies.
+	if newSecret.Address == "" {
+		return nil, maskAnyf(invalidConfigError, "Vault address must not be empty")
+	}
+	// Settings.
+	if newSecret.HTTPClient == nil {
+		return nil, maskAnyf(invalidConfigError, "HTTP client must not be empty")
+	}
+	if newSecret.AdminToken == "" {
+		return nil, maskAnyf(invalidConfigError, "Vault admin token must not be empty")
+	}
+
+	return newSecret, nil
+}
+
+type vault struct {
+	Config
+}
+
+func (v *vault) NewClient() (*vaultclient.Client, error) {
+	newClientConfig := vaultclient.DefaultConfig()
+	newClientConfig.Address = v.Address
+	newClientConfig.HttpClient = v.HTTPClient
+	newVaultClient, err := vaultclient.NewClient(newClientConfig)
+	if err != nil {
+		return nil, maskAny(err)
+	}
+	newVaultClient.SetToken(v.AdminToken)
+
+	return newVaultClient, nil
+}


### PR DESCRIPTION
This goes towards giantswarm/giantswarm#704. Note that this PR is based on #2. It enables the certificate sidekick to create properly configured Vault clients.

```
vagrant@xenial vault-client ✗ ./certificate-sidekick generate
Generate certificates.

Usage:
  certificate-sidekick generate [flags]
  certificate-sidekick generate [command]

Available Commands:
  ca          Generate a certificate authority.
  signed      Generate signed certificates.

Flags:
  -h, --help   help for generate

Use "certificate-sidekick generate [command] --help" for more information about a command.
```

```
vagrant@xenial vault-client ✗ ./certificate-sidekick generate ca
2016/08/03 13:13:30 [{/usr/code/.gobuild/src/github.com/giantswarm/certificate-sidekick/cli/generate_ca.go:33: invalid config: Vault token must not be empty}]
```

```
vagrant@xenial vault-client ✗ ./certificate-sidekick generate ca --vault-token=foo
&vaultfactory.vault{Config:vaultfactory.Config{HTTPClient:(*http.Client)(0xc820015170), Address:"http://127.0.0.1:8200", AdminToken:"foo"}}
```

```
vagrant@xenial vault-client ✗ ./certificate-sidekick generate signed
2016/08/03 13:13:48 [{/usr/code/.gobuild/src/github.com/giantswarm/certificate-sidekick/cli/generate_signed.go:33: invalid config: Vault token must not be empty}]

```

```
vagrant@xenial vault-client ✗ ./certificate-sidekick generate signed --vault-token=foo
&vaultfactory.vault{Config:vaultfactory.Config{HTTPClient:(*http.Client)(0xc820015170), Address:"http://127.0.0.1:8200", AdminToken:"foo"}}
```

RFR @teemow @hectorj2f
