### PR TITLE
renamed certificate-sidekick to certctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .gobuild/
-certificate-sidekick
+certctl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # How to contribute
 
-`certificate-sidekick` is Apache 2.0 licensed and accepts contributions via GitHub
+`certctl` is Apache 2.0 licensed and accepts contributions via GitHub
 pull requests. This document outlines some of the conventions on commit message
 formatting, contact points for developers and other resources to make getting
-your contribution into `certificate-sidekick` easier.
+your contribution into `certctl` easier.
 
 # Email and chat
 
@@ -13,13 +13,13 @@ your contribution into `certificate-sidekick` easier.
 ## Getting started
 
 - Fork the repository on GitHub
-- Read the [README.md](https://github.com/giantswarm/certificate-sidekick/blob/master/README.md) for build instructions
+- Read the [README.md](https://github.com/giantswarm/certctl/blob/master/README.md) for build instructions
 
 ## Reporting Bugs and Creating Issues
 
 Reporting bugs is one of the best ways to contribute. If you find bugs or
-documentation mistakes in the `certificate-sidekick` project, please let us know by
-[opening an issue](https://github.com/giantswarm/certificate-sidekick/issues/new). We
+documentation mistakes in the `certctl` project, please let us know by
+[opening an issue](https://github.com/giantswarm/certctl/issues/new). We
 treat bugs and mistakes very seriously and believe no issue is too small.
 Before creating a bug report, please check there that one does not already
 exist.
@@ -30,7 +30,7 @@ To make your bug report accurate and easy to understand, please try to create bu
 
 - Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please includes the steps that might lead to the problem. If applicable, you can also attach affected data dir(s) and a stack trace to the bug report.
 
-- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on `certificate-sidekick` is out of scope, but we are happy to point you in the right direction or help you interact with `certificate-sidekick` in the correct manner.
+- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on `certctl` is out of scope, but we are happy to point you in the right direction or help you interact with `certctl` in the correct manner.
 
 - Unique. Do not duplicate existing bug reports.
 
@@ -51,7 +51,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
-- Submit a pull request to giantswarm/certificate-sidekick.
+- Submit a pull request to giantswarm/certctl.
 - Adding unit tests will greatly improve the chance for getting a quick review and your PR accepted.
 - Your PR must receive a LGTM from one maintainer found in the MAINTAINERS file.
 - Before merging your PR be sure to squash all commits into one.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM busybox:ubuntu-14.04
 
 RUN mkdir -p /opt
-ADD ./certificate-sidekick /opt/certificate-sidekick
+ADD ./certctl /opt/certctl
 
-ENTRYPOINT ["/opt/certificate-sidekick"]
+ENTRYPOINT ["/opt/certctl"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT=certificate-sidekick
+PROJECT=certctl
 
 BUILD_PATH := $(shell pwd)/.gobuild
 
@@ -55,10 +55,10 @@ $(BIN): VERSION $(SOURCE)
 		-w /usr/code \
 		golang:$(GOVERSION) \
 		go build -a -ldflags "\
-			-X github.com/giantswarm/certificate-sidekick/cli.version=$(VERSION) \
-			-X github.com/giantswarm/certificate-sidekick/cli.goVersion=$(GOVERSION) \
-			-X github.com/giantswarm/certificate-sidekick/cli.gitCommit=$(COMMIT) \
-			-X github.com/giantswarm/certificate-sidekick/cli.osArch=$(GOOS)/$(GOARCH)\
+			-X github.com/giantswarm/certctl/cli.version=$(VERSION) \
+			-X github.com/giantswarm/certctl/cli.goVersion=$(GOVERSION) \
+			-X github.com/giantswarm/certctl/cli.gitCommit=$(COMMIT) \
+			-X github.com/giantswarm/certctl/cli.osArch=$(GOOS)/$(GOARCH)\
 		" \
 		-o $(BIN)
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# certificate-sidekick
+# certctl
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/certificate-sidekick)](https://goreportcard.com/report/github.com/giantswarm/certificate-sidekick)
-[![Godoc](https://godoc.org/github.com/giantswarm/certificate-sidekick?status.svg)](http://godoc.org/github.com/giantswarm/certificate-sidekick)
+[![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/certctl)](https://goreportcard.com/report/github.com/giantswarm/certctl)
+[![Godoc](https://godoc.org/github.com/giantswarm/certctl?status.svg)](http://godoc.org/github.com/giantswarm/certctl)
 [![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/service/irc.freenode.net/#giantswarm)
 
-A sidekick process able to request certificate generation from Vault to write files to the local filesystem.
+A command line tool able to request certificate generation from Vault to write certificate files to the local filesystem.
 
-## Getting `certificate-sidekick`
+## Getting `certctl`
 
-Download the latest release: https://github.com/giantswarm/certificate-sidekick/releases/latest
+Download the latest release: https://github.com/giantswarm/certctl/releases/latest
 
-Clone the git repository: https://github.com/giantswarm/certificate-sidekick.git
+Clone the git repository: https://github.com/giantswarm/certctl.git
 
 ## Contact
 
 - Mailing list: [giantswarm](https://groups.google.com/forum/!forum/giantswarm)
 - IRC: #[giantswarm](irc://irc.freenode.org:6667/#giantswarm) on freenode.org
-- Bugs: [issues](https://github.com/giantswarm/certificate-sidekick/issues)
+- Bugs: [issues](https://github.com/giantswarm/certctl/issues)
 
 ## Contributing & Reporting Bugs
 
@@ -24,4 +24,4 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches, the contr
 
 ## License
 
-`certificate-sidekick` is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.
+`certctl` is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,8 +8,8 @@ import (
 
 var (
 	CLICmd = &cobra.Command{
-		Use:   "certificate-sidekick",
-		Short: "A sidekick process able to request certificate generation from Vault to write files to the local filesystem.",
+		Use:   "certctl",
+		Short: "A command line tool able to request certificate generation from Vault to write certificate files to the local filesystem.",
 
 		Run: cliRun,
 	}

--- a/cli/generate_ca.go
+++ b/cli/generate_ca.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/certificate-sidekick/service/vault-factory"
+	"github.com/giantswarm/certctl/service/vault-factory"
 )
 
 var (

--- a/cli/generate_signed.go
+++ b/cli/generate_signed.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/certificate-sidekick/service/vault-factory"
+	"github.com/giantswarm/certctl/service/vault-factory"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/giantswarm/certificate-sidekick/cli"
+	"github.com/giantswarm/certctl/cli"
 )
 
 func main() {

--- a/service/vault-factory/vault_factory.go
+++ b/service/vault-factory/vault_factory.go
@@ -5,7 +5,7 @@ import (
 
 	vaultclient "github.com/hashicorp/vault/api"
 
-	"github.com/giantswarm/certificate-sidekick/service/spec"
+	"github.com/giantswarm/certctl/service/spec"
 )
 
 // Config represents the configuration used to create a new Vault factory.


### PR DESCRIPTION
Regarding a slack discussion we want to rename the project. See https://gigantic.slack.com/archives/kubernetes/p1470231745000995

RFR @teemow @hectorj2f 
