### PR TITLE
read vault addr and token from env

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"os"
+)
+
+func fromEnv(key, def string) string {
+	value := os.Getenv(key)
+
+	if value == "" {
+		return def
+	}
+
+	return value
+}

--- a/cli/inspect.go
+++ b/cli/inspect.go
@@ -33,9 +33,8 @@ var (
 func init() {
 	CLICmd.AddCommand(inspectCmd)
 
-	// TODO fetch address and token from environment variables if available.
-	inspectCmd.Flags().StringVar(&newInspectFlags.VaultAddress, "vault-address", "http://127.0.0.1:8200", "Address used to connect to Vault.")
-	inspectCmd.Flags().StringVar(&newInspectFlags.VaultToken, "vault-token", "", "Token used to authenticate against Vault.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultAddress, "vault-addr", fromEnv("VAULT_ADDR", "http://127.0.0.1:8200"), "Address used to connect to Vault.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultToken, "vault-token", fromEnv("VAULT_TOKEN", ""), "Token used to authenticate against Vault.")
 
 	inspectCmd.Flags().StringVar(&newInspectFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new root CA for.")
 }

--- a/cli/issue.go
+++ b/cli/issue.go
@@ -34,8 +34,8 @@ var (
 func init() {
 	CLICmd.AddCommand(issueCmd)
 
-	issueCmd.Flags().StringVar(&newIssueFlags.VaultAddress, "vault-address", "http://127.0.0.1:8200", "Address used to connect to Vault.")
-	issueCmd.Flags().StringVar(&newIssueFlags.VaultToken, "vault-token", "", "Token used to authenticate against Vault.")
+	issueCmd.Flags().StringVar(&newIssueFlags.VaultAddress, "vault-addr", fromEnv("VAULT_ADDR", "http://127.0.0.1:8200"), "Address used to connect to Vault.")
+	issueCmd.Flags().StringVar(&newIssueFlags.VaultToken, "vault-token", fromEnv("VAULT_TOKEN", ""), "Token used to authenticate against Vault.")
 
 	issueCmd.Flags().StringVar(&newIssueFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new signed certificate for.")
 	issueCmd.Flags().StringVar(&newIssueFlags.CommonName, "common-name", "", "Common name used to generate a new root CA for.")

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -44,8 +44,8 @@ var (
 func init() {
 	CLICmd.AddCommand(setupCmd)
 
-	setupCmd.Flags().StringVar(&newSetupFlags.VaultAddress, "vault-address", "http://127.0.0.1:8200", "Address used to connect to Vault.")
-	setupCmd.Flags().StringVar(&newSetupFlags.VaultToken, "vault-token", "", "Token used to authenticate against Vault.")
+	setupCmd.Flags().StringVar(&newSetupFlags.VaultAddress, "vault-addr", fromEnv("VAULT_ADDR", "http://127.0.0.1:8200"), "Address used to connect to Vault.")
+	setupCmd.Flags().StringVar(&newSetupFlags.VaultToken, "vault-token", fromEnv("VAULT_TOKEN", ""), "Token used to authenticate against Vault.")
 
 	setupCmd.Flags().StringVar(&newSetupFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new root CA for.")
 


### PR DESCRIPTION
This PR fixes 18. The result looks like this. Note that this is based against #17, because there are all commands needed to be changed.
### before

```
certctl inspect --vault-addr=https://leaseweb-vault-private.giantswarm.io:8200 --vault-token=$(cat ~/.giantswarm_vault_token) --cluster-id=123
```
### after

```
certctl inspect --cluster-id=123
```
