### PR TITLE
added builder.json to always release public

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -1,0 +1,3 @@
+{
+    "release-public": true
+}


### PR DESCRIPTION
This is to make sure we always push docker images of a release to the public docker hub when making releases with `builder`. It is a little bit contradictory that we want to use the public registry of docker but have the repository private. 

See the builder documentation here: https://github.com/giantswarm/builder#always-push-to-docker-hub.

RFR @hectorj2f @JosephSalisbury 
