### PR TITLE
cleanup PKI backends

### DIFF
--- a/cli/cleanup.go
+++ b/cli/cleanup.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/certctl/service/pki-controller"
+	"github.com/giantswarm/certctl/service/token-generator"
+	"github.com/giantswarm/certctl/service/vault-factory"
+)
+
+type cleanupFlags struct {
+	// Vault
+	VaultAddress string
+	VaultToken   string
+
+	// Cluster
+	ClusterID string
+}
+
+var (
+	cleanupCmd = &cobra.Command{
+		Use:   "cleanup",
+		Short: "Cleanup a Vault PKI backend including all necessary requirements.",
+		Run:   cleanupRun,
+	}
+
+	newCleanupFlags = &cleanupFlags{}
+)
+
+func init() {
+	CLICmd.AddCommand(cleanupCmd)
+
+	cleanupCmd.Flags().StringVar(&newCleanupFlags.VaultAddress, "vault-addr", fromEnv("VAULT_ADDR", "http://127.0.0.1:8200"), "Address used to connect to Vault.")
+	cleanupCmd.Flags().StringVar(&newCleanupFlags.VaultToken, "vault-token", fromEnv("VAULT_TOKEN", ""), "Token used to authenticate against Vault.")
+
+	cleanupCmd.Flags().StringVar(&newCleanupFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new root CA for.")
+}
+
+func cleanupValidate(newCleanupFlags *cleanupFlags) error {
+	if newCleanupFlags.VaultToken == "" {
+		return maskAnyf(invalidConfigError, "Vault token must not be empty")
+	}
+	if newCleanupFlags.ClusterID == "" {
+		return maskAnyf(invalidConfigError, "cluster ID must not be empty")
+	}
+
+	return nil
+}
+
+func cleanupRun(cmd *cobra.Command, args []string) {
+	err := cleanupValidate(newCleanupFlags)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+
+	// Create a Vault client factory.
+	newVaultFactoryConfig := vaultfactory.DefaultConfig()
+	newVaultFactoryConfig.HTTPClient = &http.Client{}
+	newVaultFactoryConfig.Address = newCleanupFlags.VaultAddress
+	newVaultFactoryConfig.AdminToken = newCleanupFlags.VaultToken
+	newVaultFactory, err := vaultfactory.New(newVaultFactoryConfig)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+
+	// Create a Vault client and configure it with the provided admin token
+	// through the factory.
+	newVaultClient, err := newVaultFactory.NewClient()
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+
+	// Create a PKI controller to cleanup PKI backend specific operations.
+	newPKIControllerConfig := pkicontroller.DefaultConfig()
+	newPKIControllerConfig.VaultClient = newVaultClient
+	newPKIController, err := pkicontroller.New(newPKIControllerConfig)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+
+	// Create a token generator to cleanup token specific operations.
+	newTokenGeneratorConfig := tokengenerator.DefaultConfig()
+	newTokenGeneratorConfig.VaultClient = newVaultClient
+	newTokenGenerator, err := tokengenerator.New(newTokenGeneratorConfig)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+
+	err = newPKIController.DeletePKIBackend(newCleanupFlags.ClusterID)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	err = newTokenGenerator.DeletePKIIssuePolicy(newCleanupFlags.ClusterID)
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+
+	fmt.Printf("Inspecting cluster for ID '%s':\n", newCleanupFlags.ClusterID)
+	fmt.Printf("\n")
+	fmt.Printf("    - PKI backend unmounted\n")
+	fmt.Printf("    - Root CA deleted\n")
+	fmt.Printf("    - PKI role deleted\n")
+	fmt.Printf("    - PKI policy deleted\n")
+	fmt.Printf("\n")
+	fmt.Printf("Tokens may have been generated for this cluster. Created tokens\n")
+	fmt.Printf("cannot be revoked here as they are secret. Tokens need to be\n")
+	fmt.Printf("revoked manually. In case a cluster with the same ID will be\n")
+	fmt.Printf("generated, tokens generated for this cluster will be able to\n")
+	fmt.Printf("access this new cluster again. Information about these secrets\n")
+	fmt.Printf("needs to be looked up directly from the location of the cluster's\n")
+	fmt.Printf("installation.\n")
+}

--- a/service/pki-controller/pki_controller.go
+++ b/service/pki-controller/pki_controller.go
@@ -53,6 +53,26 @@ type pkiController struct {
 
 // PKI management.
 
+func (pc *pkiController) DeletePKIBackend(clusterID string) error {
+	// Create a client for the system backend configured with the Vault token
+	// used for the current cluster's PKI backend.
+	sysBackend := pc.VaultClient.Sys()
+
+	// Unmount the PKI backend, if it exists.
+	mounted, err := pc.IsPKIMounted(clusterID)
+	if err != nil {
+		return maskAny(err)
+	}
+	if mounted {
+		err = sysBackend.Unmount(pc.MountPKIPath(clusterID))
+		if err != nil {
+			return maskAny(err)
+		}
+	}
+
+	return nil
+}
+
 func (pc *pkiController) IsCAGenerated(clusterID string) (bool, error) {
 	// Create a client for the logical backend configured with the Vault token
 	// used for the current cluster's PKI backend.

--- a/service/spec/pki_controller.go
+++ b/service/spec/pki_controller.go
@@ -28,6 +28,10 @@ type PKIConfig struct {
 type PKIController interface {
 	// PKI management.
 
+	// DeletePKIBackend removes the PKI backend associated wit the given cluster
+	// ID.
+	DeletePKIBackend(clusterID string) error
+
 	// IsCAGenerated checks whether the root CA associated with the given cluster
 	// ID is generated.
 	IsCAGenerated(clusterID string) (bool, error)

--- a/service/spec/token_generator.go
+++ b/service/spec/token_generator.go
@@ -19,6 +19,9 @@ type TokenConfig struct {
 // TokenGenerator creates new Vault policies to restrict access capabilities
 // of e.g. Vault tokens.
 type TokenGenerator interface {
+	// DeletePKIIssuePolicy removes a policy from Vault using its name.
+	DeletePKIIssuePolicy(clusterID string) error
+
 	// IsPKIIssuePolicyCreated checks whether the PKI issue policy already
 	// exists.
 	IsPKIIssuePolicyCreated(clusterID string) (bool, error)


### PR DESCRIPTION
This PR provides a `cleanup` command. I had the issue of getting rid of all the data in Vault created while testing. When unmounting a PKI backend the policy roles have been left. So I put everything into one new command. Note that this PR is based on #22.

```
vagrant@xenial cleanup ✗ ./certctl inspect --cluster-id=123
Inspecting cluster for ID '123':

    PKI backend mounted: false
    Root CA generated:   false
    PKI role created:    false
    PKI policy created:  true

Tokens may have been generated for this cluster. Created tokens
cannot be shown as they are secret. Information about these
secrets needs to be looked up directly from the location of the
cluster's installation.
```

```
vagrant@xenial cleanup ✗ ./certctl cleanup --cluster-id=123
Inspecting cluster for ID '123':

    - PKI backend unmounted
    - Root CA deleted
    - PKI role deleted
    - PKI policy deleted

Tokens may have been generated for this cluster. Created tokens
cannot be revoked here as they are secret. Tokens need to be
revoked manually. In case a cluster with the same ID will be
generated, tokens generated for this cluster will be able to
access this new cluster again. Information about these secrets
needs to be looked up directly from the location of the cluster's
installation.
```

```
vagrant@xenial cleanup ✗ ./certctl inspect --cluster-id=123
Inspecting cluster for ID '123':

    PKI backend mounted: false
    Root CA generated:   false
    PKI role created:    false
    PKI policy created:  false

Tokens may have been generated for this cluster. Created tokens
cannot be shown as they are secret. Information about these
secrets needs to be looked up directly from the location of the
cluster's installation.
```

RFR @hectorj2f @JosephSalisbury 
