### PR TITLE
provide proper output when setting up a cluster

### DIFF
--- a/cli/setup.go
+++ b/cli/setup.go
@@ -137,7 +137,17 @@ func setupRun(cmd *cobra.Command, args []string) {
 		log.Fatalf("%#v\n", maskAny(err))
 	}
 
-	fmt.Printf("%#v\n", tokens)
-
-	// TODO proper output of what happened.
+	fmt.Printf("Set up cluster for ID '%s':\n", newSetupFlags.ClusterID)
+	fmt.Printf("\n")
+	fmt.Printf("    - PKI backend mounted\n")
+	fmt.Printf("    - Root CA generated\n")
+	fmt.Printf("    - PKI role created\n")
+	fmt.Printf("    - PKI policy created\n")
+	fmt.Printf("\n")
+	fmt.Printf("The following tokens have been generated for this cluster:\n")
+	fmt.Printf("\n")
+	for _, t := range tokens {
+		fmt.Printf("    %s\n", t)
+	}
+	fmt.Printf("\n")
 }


### PR DESCRIPTION
This PR provides better output for the `setup` command so you know what actually happened. 

```
vagrant@xenial setup ✗ ./certctl setup --allowed-domains=giantswarm.io --common-name=giantswarm.io --cluster-id=123
Set up cluster for ID '123':

    - PKI backend mounted
    - Root CA generated
    - PKI role created
    - PKI policy created

The following tokens have been generated for this cluster:

    df7d84b4-41c1-4364-995b-62f3a8be2011

```

RFR @JosephSalisbury @hectorj2f 
