### PR TITLE
be more tolerant on TTLs

### DIFF
--- a/cli/issue.go
+++ b/cli/issue.go
@@ -50,7 +50,7 @@ func init() {
 	issueCmd.Flags().StringVar(&newIssueFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new signed certificate for.")
 
 	issueCmd.Flags().StringVar(&newIssueFlags.CommonName, "common-name", "", "Common name used to generate a new root CA for.")
-	issueCmd.Flags().StringVar(&newIssueFlags.TTL, "ttl", "719h", "TTL used to generate a new signed certificate for.")
+	issueCmd.Flags().StringVar(&newIssueFlags.TTL, "ttl", "8640h", "TTL used to generate a new signed certificate for.") // 1 year
 
 	issueCmd.Flags().StringVar(&newIssueFlags.CrtFilePath, "crt-file", "", "File path used to write the generated public key to.")
 	issueCmd.Flags().StringVar(&newIssueFlags.KeyFilePath, "key-file", "", "File path used to write the generated private key to.")

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -51,7 +51,7 @@ func init() {
 
 	setupCmd.Flags().StringVar(&newSetupFlags.AllowedDomains, "allowed-domains", "", "Comma separated domains allowed to authenticate against the cluster's root CA.")
 	setupCmd.Flags().StringVar(&newSetupFlags.CommonName, "common-name", "", "Common name used to generate a new root CA for.")
-	setupCmd.Flags().StringVar(&newSetupFlags.CATTL, "ca-ttl", "720h", "TTL used to generate a new root CA.")
+	setupCmd.Flags().StringVar(&newSetupFlags.CATTL, "ca-ttl", "86400h", "TTL used to generate a new root CA.") // 10 years
 
 	setupCmd.Flags().IntVar(&newSetupFlags.NumTokens, "num-tokens", 1, "Number of tokens to generate.")
 	setupCmd.Flags().StringVar(&newSetupFlags.TokenTTL, "token-ttl", "720h", "TTL used to generate new tokens.")


### PR DESCRIPTION
This PR is supposed to give us enough headroom for TTLs on root CAs and issued certificates. I want the TTLs to be that open to not run into the following errors in production. 

```
Aug 10 09:20:39 core-01 docker[8690]: 2016/08/10 09:20:39 [{/usr/code/.gobuild/src/github.com/giantswarm/certctl/cli/issue.go:122: } {/usr/code/.gobuild/src/github.com/giantswarm/certctl/service/cert-signer/cert_signer.go:67: } {Error making API request.
Aug 10 09:20:39 core-01 docker[8690]: URL: PUT http://mgmt.local.giantswarm.io:8200/v1/pki-test-cluster/issue/role-test-cluster
Aug 10 09:20:39 core-01 docker[8690]: Code: 400. Errors:
Aug 10 09:20:39 core-01 docker[8690]: * cannot satisfy request, as TTL is beyond the expiration of the CA certificate}]
```

When it comes to certificate rotations we need to play the pro-active part. 

RFR @hectorj2f @JosephSalisbury 
