### PR TITLE
added IPSANs to make certificates work for us now

### DIFF
--- a/cli/issue.go
+++ b/cli/issue.go
@@ -23,6 +23,7 @@ type issueFlags struct {
 
 	// Certificate
 	CommonName string
+	IPSANs     string
 	TTL        string
 
 	// Path
@@ -49,7 +50,8 @@ func init() {
 
 	issueCmd.Flags().StringVar(&newIssueFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new signed certificate for.")
 
-	issueCmd.Flags().StringVar(&newIssueFlags.CommonName, "common-name", "", "Common name used to generate a new root CA for.")
+	issueCmd.Flags().StringVar(&newIssueFlags.CommonName, "common-name", "", "Common name used to generate a new signed certificate for.")
+	issueCmd.Flags().StringVar(&newIssueFlags.IPSANs, "ip-sans", "", "IPSANs used to generate a new signed certificate for.")
 	issueCmd.Flags().StringVar(&newIssueFlags.TTL, "ttl", "8640h", "TTL used to generate a new signed certificate for.") // 1 year
 
 	issueCmd.Flags().StringVar(&newIssueFlags.CrtFilePath, "crt-file", "", "File path used to write the generated public key to.")
@@ -65,7 +67,10 @@ func issueValidate(newIssueFlags *issueFlags) error {
 		return maskAnyf(invalidConfigError, "cluster ID must not be empty")
 	}
 	if newIssueFlags.CommonName == "" {
-		return maskAnyf(invalidConfigError, "common name must not be empty")
+		return maskAnyf(invalidConfigError, "--common-name must not be empty")
+	}
+	if newIssueFlags.IPSANs == "" {
+		return maskAnyf(invalidConfigError, "--ip-sans must not be empty")
 	}
 	if newIssueFlags.CrtFilePath == "" {
 		return maskAnyf(invalidConfigError, "--crt-file name must not be empty")
@@ -115,6 +120,7 @@ func issueRun(cmd *cobra.Command, args []string) {
 	newIssueConfig := spec.IssueConfig{
 		ClusterID:  newIssueFlags.ClusterID,
 		CommonName: newIssueFlags.CommonName,
+		IPSANs:     newIssueFlags.IPSANs,
 		TTL:        newIssueFlags.TTL,
 	}
 	crt, key, ca, err := newCertSigner.Issue(newIssueConfig)

--- a/service/cert-signer/cert_signer.go
+++ b/service/cert-signer/cert_signer.go
@@ -61,6 +61,7 @@ func (cs *certSigner) Issue(config spec.IssueConfig) (string, string, string, er
 	data := map[string]interface{}{
 		"ttl":         config.TTL,
 		"common_name": config.CommonName,
+		"ip_sans":     config.IPSANs,
 	}
 	secret, err := logicalStore.Write(cs.SignedPath(config.ClusterID), data)
 	if err != nil {

--- a/service/spec/cert_signer.go
+++ b/service/spec/cert_signer.go
@@ -11,6 +11,9 @@ type IssueConfig struct {
 	// that is being requested.
 	CommonName string `json:"common_name"`
 
+	// IPSANs represents a comma separate lists of IPs.
+	IPSANs string `json:"ip_sans"`
+
 	// TTL configures the time to live for the requested certificate. This is a
 	// golang time string with the allowed units s, m and h.
 	TTL string `json:"ttl"`


### PR DESCRIPTION
This PR re-adds IPSANs to the certificate generation to make it work for us now. See [my comment about this in the k8s-vm repo](https://github.com/giantswarm/k8s-vm/pull/52#issuecomment-239769627). Also note the releaseit PR here: https://github.com/giantswarm/releaseit/pull/544.

RFR @JosephSalisbury 
