### PR TITLE
remove IP SANs requirement check

### DIFF
--- a/cli/issue.go
+++ b/cli/issue.go
@@ -69,9 +69,6 @@ func issueValidate(newIssueFlags *issueFlags) error {
 	if newIssueFlags.CommonName == "" {
 		return maskAnyf(invalidConfigError, "--common-name must not be empty")
 	}
-	if newIssueFlags.IPSANs == "" {
-		return maskAnyf(invalidConfigError, "--ip-sans must not be empty")
-	}
 	if newIssueFlags.CrtFilePath == "" {
 		return maskAnyf(invalidConfigError, "--crt-file name must not be empty")
 	}


### PR DESCRIPTION
This PR fixes #33. With this change I am able to generate certificates without providing `--ip-sans`.

RFR @giantswarm/team-positive 
