### PR TITLE
make sure the directories used to write certs to exist

### DIFF
--- a/cli/issue.go
+++ b/cli/issue.go
@@ -126,21 +126,29 @@ func issueRun(cmd *cobra.Command, args []string) {
 		log.Fatalf("%#v\n", maskAny(err))
 	}
 
-	filePaths := []string{
-		newIssueFlags.CrtFilePath,
-		newIssueFlags.KeyFilePath,
-		newIssueFlags.CAFilePath,
+	err = os.MkdirAll(filepath.Dir(newIssueFlags.CrtFilePath), os.FileMode(0744))
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
 	}
-
-	for _, p := range filePaths {
-		err = os.MkdirAll(filepath.Dir(p), os.FileMode(0655))
-		if err != nil {
-			log.Fatalf("%#v\n", maskAny(err))
-		}
-		err = ioutil.WriteFile(p, []byte(newIssueResponse.IssuingCA), os.FileMode(0644))
-		if err != nil {
-			log.Fatalf("%#v\n", maskAny(err))
-		}
+	err = ioutil.WriteFile(newIssueFlags.CrtFilePath, []byte(newIssueResponse.Certificate), os.FileMode(0644))
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	err = os.MkdirAll(filepath.Dir(newIssueFlags.KeyFilePath), os.FileMode(0744))
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	err = ioutil.WriteFile(newIssueFlags.KeyFilePath, []byte(newIssueResponse.PrivateKey), os.FileMode(0644))
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	err = os.MkdirAll(filepath.Dir(newIssueFlags.CAFilePath), os.FileMode(0744))
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
+	}
+	err = ioutil.WriteFile(newIssueFlags.CAFilePath, []byte(newIssueResponse.IssuingCA), os.FileMode(0644))
+	if err != nil {
+		log.Fatalf("%#v\n", maskAny(err))
 	}
 
 	fmt.Printf("Issued new signed certificate with the following serial number.\n")


### PR DESCRIPTION
It can happen that the directory where certificates are supposed to be written to does not exist. This PR fixes that, by creating the directories beforehand. 

```
Oct 05 18:33:42 0a039bd74d51b324 bash[24058]: 2016/10/05 18:33:42 [{/usr/code/.gobuild/src/github.com/giantswarm/certctl/cli/issue.go:130: } {open /etc/kubernetes/ssl/etcd/client.pem: no such file or directory}]
Oct 05 18:33:43 0a039bd74d51b324 systemd[1]: xh3b4sd-k8s-worker-etcd-certs@1.service: Main process exited, code=exited, status=1/FAILURE
Oct 05 18:33:43 0a039bd74d51b324 systemd[1]: Failed to start k8s-worker-etcd-certs.
Oct 05 18:33:43 0a039bd74d51b324 systemd[1]: xh3b4sd-k8s-worker-etcd-certs@1.service: Unit entered failed state.
Oct 05 18:33:43 0a039bd74d51b324 systemd[1]: xh3b4sd-k8s-worker-etcd-certs@1.service: Failed with result 'exit-code'.
```

RFR @giantswarm/team-positive 
