### PR TITLE
retry attempts to write to file system

### DIFF
--- a/cli/issue.go
+++ b/cli/issue.go
@@ -142,7 +142,7 @@ func issueRun(cmd *cobra.Command, args []string) {
 	{
 	Attempt:
 		for {
-			log.Fatalf("Attempt to write certificate data to the file system.\n")
+			log.Printf("Attempt to write certificate data to the file system.\n")
 
 			attemptCount++
 			if attemptCount > newIssueFlags.FSWriteAttempts {


### PR DESCRIPTION
For more resiliency this PR introduces the option to retry writes to the file system. 

RFR @giantswarm/team-positive 
