### PR TITLE
Dockerfile: switch to alpine, adding ca

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM frolvlad/alpine-glibc:alpine-3.4
 
 RUN apk --no-cache add ca-certificates && update-ca-certificates
 


### PR DESCRIPTION
Change is needed cause busybox image does not have CA and errors out.