### PR TITLE
Add VerifyPKISetup helper to PKI service for use by cert-operator

### DIFF
--- a/service/pki/service.go
+++ b/service/pki/service.go
@@ -147,6 +147,35 @@ func (s *service) IsRoleCreated(clusterID string) (bool, error) {
 	return false, nil
 }
 
+func (s *service) VerifyPKISetup(clusterID string) (bool, error) {
+	mounted, err := s.IsMounted(clusterID)
+	if err != nil {
+		return false, maskAny(err)
+	}
+	if !mounted {
+		return false, nil
+	}
+
+	caGenerated, err := s.IsCAGenerated(clusterID)
+	if err != nil {
+		return false, maskAny(err)
+	}
+	if !caGenerated {
+		return false, nil
+	}
+
+	roleCreated, err := s.IsRoleCreated(clusterID)
+	if !roleCreated || err != nil {
+		return false, maskAny(err)
+	}
+	if !roleCreated {
+		return false, nil
+	}
+
+	// PKI setup is valid.
+	return true, nil
+}
+
 func (s *service) RoleName(clusterID string) string {
 	return fmt.Sprintf("role-%s", clusterID)
 }

--- a/service/pki/spec.go
+++ b/service/pki/spec.go
@@ -54,6 +54,10 @@ type Service interface {
 	// cluster ID is created.
 	IsRoleCreated(clusterID string) (bool, error)
 
+	// VerifyPKISetup checks if IsMounted, IsCAGenerated and IsRoleCreated are all true
+	// for the given cluster ID.
+	VerifyPKISetup(clusterID string) (bool, error)
+
 	// RoleName returns the name used to register the PKI backend's role.
 	RoleName(clusterID string) string
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#1255

Add VerifyPKISetup helper to PKI service that checks if IsMounted, IsCAGenerated and IsRoleCreated are all true for a cluster ID.

Will be used by cert-operator but added to certctl so it can be reused in other places.