### PR TITLE
Added options to create custom TLS configuration for Vault client

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -1,15 +1,40 @@
 package cli
 
 import (
+	"log"
 	"os"
+	"strconv"
 )
 
-func fromEnv(key, def string) string {
-	value := os.Getenv(key)
+const (
+	EnvVaultAddress       = "VAULT_ADDR"
+	EnvVaultCACert        = "VAULT_CACERT"
+	EnvVaultCAPath        = "VAULT_CAPATH"
+	EnvVaultClientCert    = "VAULT_CLIENT_CERT"
+	EnvVaultClientKey     = "VAULT_CLIENT_KEY"
+	EnvVaultInsecure      = "VAULT_SKIP_VERIFY"
+	EnvVaultTLSServerName = "VAULT_TLS_SERVER_NAME"
+	EnvVaultToken         = "VAULT_TOKEN"
+)
 
+func fromEnvToString(key, def string) string {
+	value := os.Getenv(key)
 	if value == "" {
 		return def
 	}
 
 	return value
+}
+
+func fromEnvBool(key string, def bool) bool {
+	if value := os.Getenv(key); value != "" {
+		parsedValue, err := strconv.ParseBool(value)
+		if err != nil {
+			log.Fatalf("Cannot parse %s: %s", key, err)
+		}
+
+		return parsedValue
+	}
+
+	return def
 }

--- a/cli/inspect.go
+++ b/cli/inspect.go
@@ -3,9 +3,10 @@ package cli
 import (
 	"fmt"
 	"log"
-	"net/http"
 
 	"github.com/spf13/cobra"
+
+	vaultclient "github.com/hashicorp/vault/api"
 
 	"github.com/giantswarm/certctl/service/pki"
 	"github.com/giantswarm/certctl/service/token"
@@ -16,6 +17,7 @@ type inspectFlags struct {
 	// Vault
 	VaultAddress string
 	VaultToken   string
+	VaultTLS     *vaultclient.TLSConfig
 
 	// Cluster
 	ClusterID string
@@ -28,14 +30,22 @@ var (
 		Run:   inspectRun,
 	}
 
-	newInspectFlags = &inspectFlags{}
+	newInspectFlags = &inspectFlags{
+		VaultTLS: &vaultclient.TLSConfig{},
+	}
 )
 
 func init() {
 	CLICmd.AddCommand(inspectCmd)
 
-	inspectCmd.Flags().StringVar(&newInspectFlags.VaultAddress, "vault-addr", fromEnv("VAULT_ADDR", "http://127.0.0.1:8200"), "Address used to connect to Vault.")
-	inspectCmd.Flags().StringVar(&newInspectFlags.VaultToken, "vault-token", fromEnv("VAULT_TOKEN", ""), "Token used to authenticate against Vault.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultAddress, "vault-addr", fromEnvToString(EnvVaultAddress, "http://127.0.0.1:8200"), "Address used to connect to Vault.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultToken, "vault-token", fromEnvToString(EnvVaultToken, ""), "Token used to authenticate against Vault.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultTLS.CACert, "vault-cacert", fromEnvToString(EnvVaultCACert, ""), "The path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultTLS.CAPath, "vault-capath", fromEnvToString(EnvVaultCAPath, ""), "The path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultTLS.ClientCert, "vault-client-cert", fromEnvToString(EnvVaultClientCert, ""), "The path to the certificate for Vault communication.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultTLS.ClientKey, "vault-client-key", fromEnvToString(EnvVaultClientKey, ""), "The path to the private key for Vault communication.")
+	inspectCmd.Flags().StringVar(&newInspectFlags.VaultTLS.TLSServerName, "vault-tls-server-name", fromEnvToString(EnvVaultTLSServerName, ""), "If set, is used to set the SNI host when connecting via TLS.")
+	inspectCmd.Flags().BoolVar(&newInspectFlags.VaultTLS.Insecure, "vault-tls-skip-verify", fromEnvBool(EnvVaultInsecure, false), "Do not verify TLS certificate.")
 
 	inspectCmd.Flags().StringVar(&newInspectFlags.ClusterID, "cluster-id", "", "Cluster ID used to generate a new root CA for.")
 }
@@ -59,9 +69,9 @@ func inspectRun(cmd *cobra.Command, args []string) {
 
 	// Create a Vault client factory.
 	newVaultFactoryConfig := vaultfactory.DefaultConfig()
-	newVaultFactoryConfig.HTTPClient = &http.Client{}
 	newVaultFactoryConfig.Address = newInspectFlags.VaultAddress
 	newVaultFactoryConfig.AdminToken = newInspectFlags.VaultToken
+	newVaultFactoryConfig.TLS = newInspectFlags.VaultTLS
 	newVaultFactory, err := vaultfactory.New(newVaultFactoryConfig)
 	if err != nil {
 		log.Fatalf("%#v\n", maskAny(err))

--- a/service/cert-signer/cert_signer.go
+++ b/service/cert-signer/cert_signer.go
@@ -2,7 +2,6 @@ package certsigner
 
 import (
 	"fmt"
-	"net/http"
 
 	vaultclient "github.com/hashicorp/vault/api"
 
@@ -20,7 +19,6 @@ type Config struct {
 func DefaultConfig() Config {
 	newClientConfig := vaultclient.DefaultConfig()
 	newClientConfig.Address = "http://127.0.0.1:8200"
-	newClientConfig.HttpClient = http.DefaultClient
 	newVaultClient, err := vaultclient.NewClient(newClientConfig)
 	if err != nil {
 		panic(err)

--- a/service/pki/service.go
+++ b/service/pki/service.go
@@ -2,7 +2,6 @@ package pki
 
 import (
 	"fmt"
-	"net/http"
 
 	vaultclient "github.com/hashicorp/vault/api"
 )
@@ -17,7 +16,6 @@ type ServiceConfig struct {
 func DefaultServiceConfig() ServiceConfig {
 	newClientConfig := vaultclient.DefaultConfig()
 	newClientConfig.Address = "http://127.0.0.1:8200"
-	newClientConfig.HttpClient = http.DefaultClient
 	newVaultClient, err := vaultclient.NewClient(newClientConfig)
 	if err != nil {
 		panic(err)

--- a/service/token/service.go
+++ b/service/token/service.go
@@ -2,7 +2,6 @@ package token
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/giantswarm/go-uuid/uuid"
 	vaultclient "github.com/hashicorp/vault/api"
@@ -18,7 +17,6 @@ type ServiceConfig struct {
 func DefaultServiceConfig() ServiceConfig {
 	newClientConfig := vaultclient.DefaultConfig()
 	newClientConfig.Address = "http://127.0.0.1:8200"
-	newClientConfig.HttpClient = http.DefaultClient
 	newVaultClient, err := vaultclient.NewClient(newClientConfig)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Hi,

Now there is lack of options to TLS configuration for Vault client. This situation can causes some an issues, especially in case when someone uses self-signed certs. This PR should solve #41 issue as well.