### PR TITLE
Strict permissions for private key

### DIFF
--- a/cli/issue.go
+++ b/cli/issue.go
@@ -163,7 +163,7 @@ func issueRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("%#v\n", microerror.Mask(err))
 	}
-	err = ioutil.WriteFile(newIssueFlags.KeyFilePath, []byte(newIssueResponse.PrivateKey), os.FileMode(0644))
+	err = ioutil.WriteFile(newIssueFlags.KeyFilePath, []byte(newIssueResponse.PrivateKey), os.FileMode(0600))
 	if err != nil {
 		log.Fatalf("%#v\n", microerror.Mask(err))
 	}


### PR DESCRIPTION
Use 600 instead of 644.

Related to https://github.com/giantswarm/giantswarm/issues/1680#issuecomment-336806139