### PR TITLE
Create system:masters org policy during setup

### DIFF
--- a/cli/cleanup.go
+++ b/cli/cleanup.go
@@ -111,6 +111,10 @@ func cleanupRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("%#v\n", microerror.Mask(err))
 	}
+	err = tokenService.DeleteOrgPolicy(newCleanupFlags.ClusterID)
+	if err != nil {
+		log.Fatalf("%#v\n", microerror.Mask(err))
+	}
 	err = tokenService.DeletePolicy(newCleanupFlags.ClusterID)
 	if err != nil {
 		log.Fatalf("%#v\n", microerror.Mask(err))

--- a/cli/issue.go
+++ b/cli/issue.go
@@ -137,14 +137,15 @@ func issueRun(cmd *cobra.Command, args []string) {
 
 	// Generate a new signed certificate.
 	newIssueConfig := spec.IssueConfig{
-		ClusterID:      newIssueFlags.ClusterID,
-		CommonName:     newIssueFlags.CommonName,
-		Organizations:  newIssueFlags.Organizations,
-		AllowedDomains: newIssueFlags.AllowedDomains,
-		IPSANs:         newIssueFlags.IPSANs,
-		AltNames:       newIssueFlags.AltNames,
-		TTL:            newIssueFlags.TTL,
-		RoleTTL:        newIssueFlags.RoleTTL,
+		ClusterID:        newIssueFlags.ClusterID,
+		CommonName:       newIssueFlags.CommonName,
+		Organizations:    newIssueFlags.Organizations,
+		AllowedDomains:   newIssueFlags.AllowedDomains,
+		AllowBareDomains: newIssueFlags.AllowBareDomains,
+		IPSANs:           newIssueFlags.IPSANs,
+		AltNames:         newIssueFlags.AltNames,
+		TTL:              newIssueFlags.TTL,
+		RoleTTL:          newIssueFlags.RoleTTL,
 	}
 	newIssueResponse, err := newCertSigner.Issue(newIssueConfig)
 	if err != nil {

--- a/service/token/service.go
+++ b/service/token/service.go
@@ -116,7 +116,7 @@ func (s *service) CreateOrgPolicy(clusterID string) error {
 	// Create organization policy name and HCL policy rules.
 	orgPolicyName := s.OrgPolicyName(clusterID)
 	organizationsRoleHash := computeRoleHash(systemMastersOrganizations)
-	rules, err := execTemplate(pkiIssueOrgPolicyTemplate, pkiIssueOrgPolicyContext{OrganizationsRoleHash: organizationsRoleHash})
+	rules, err := execTemplate(pkiIssueOrgPolicyTemplate, pkiIssueOrgPolicyContext{ClusterID: clusterID, OrganizationsRoleHash: organizationsRoleHash})
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/token/service.go
+++ b/service/token/service.go
@@ -1,11 +1,18 @@
 package token
 
 import (
+	"crypto/sha1"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/giantswarm/go-uuid/uuid"
 	"github.com/giantswarm/microerror"
 	vaultclient "github.com/hashicorp/vault/api"
+)
+
+const (
+	systemMastersOrganizations = "system:masters"
 )
 
 // ServiceConfig represents the configuration used to create a new service.
@@ -52,12 +59,25 @@ type service struct {
 func (s *service) Create(config CreateConfig) ([]string, error) {
 	// In case there does no policy exist that allows to issue certificates on a
 	// PKI backend, create one.
-	created, err := s.IsPolicyCreated(config.ClusterID)
+	policyCreated, err := s.IsPolicyCreated(config.ClusterID)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	if !created {
+	if !policyCreated {
 		err := s.CreatePolicy(config.ClusterID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	// In case there is no policy exist that allows to issue certificates
+	// with organization on a PKI backend, create one.
+	orgPolicyCreated, err := s.IsOrgPolicyCreated(config.ClusterID)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if !orgPolicyCreated {
+		err := s.CreateOrgPolicy(config.ClusterID)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -89,6 +109,27 @@ func (s *service) Create(config CreateConfig) ([]string, error) {
 	return tokens, nil
 }
 
+func (s *service) CreateOrgPolicy(clusterID string) error {
+	// Get the system backend for policy operations.
+	sysBackend := s.VaultClient.Sys()
+
+	// Create organization policy name and HCL policy rules.
+	orgPolicyName := s.OrgPolicyName(clusterID)
+	organizationsRoleHash := computeRoleHash(systemMastersOrganizations)
+	rules, err := execTemplate(pkiIssueOrgPolicyTemplate, pkiIssueOrgPolicyContext{OrganizationsRoleHash: organizationsRoleHash})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Actually create the policy within Vault.
+	err = sysBackend.PutPolicy(orgPolicyName, rules)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
 func (s *service) CreatePolicy(clusterID string) error {
 	// Get the system backend for policy operations.
 	sysBackend := s.VaultClient.Sys()
@@ -104,6 +145,25 @@ func (s *service) CreatePolicy(clusterID string) error {
 	err = sysBackend.PutPolicy(policyName, rules)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (s *service) DeleteOrgPolicy(clusterID string) error {
+	// Get the system backend for policy operations.
+	sysBackend := s.VaultClient.Sys()
+
+	// Delete the policy by name if it is created.
+	created, err := s.IsPolicyCreated(clusterID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if created {
+		err := sysBackend.DeletePolicy(s.OrgPolicyName(clusterID))
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	return nil
@@ -146,6 +206,47 @@ func (s *service) IsPolicyCreated(clusterID string) (bool, error) {
 	return false, nil
 }
 
+func (s *service) IsOrgPolicyCreated(clusterID string) (bool, error) {
+	// Get the system backend for policy operations.
+	sysBackend := s.VaultClient.Sys()
+
+	// Check if the policy is already there.
+	policies, err := sysBackend.ListPolicies()
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+	for _, p := range policies {
+		if p == s.OrgPolicyName(clusterID) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *service) OrgPolicyName(clusterID string) string {
+	return fmt.Sprintf("pki-issue-policy-%s-org", clusterID)
+}
+
 func (s *service) PolicyName(clusterID string) string {
 	return fmt.Sprintf("pki-issue-policy-%s", clusterID)
+}
+
+// computeRoleHash computes a hash for the role that can issue these organizations.
+// Since we want to reuse roles when possible, we should try to make sure that
+// the same list of organizations returns the same hash (regardless of the order).
+// The reason we don't use just the organizations that the user provided is because
+// that could potentially be a very long list, or otherwise contain characters
+// that are not allowed in URLs.
+func computeRoleHash(organizations string) string {
+	// Sort organizations alphabetically
+	organizationsSlice := strings.Split(organizations, ",")
+	sort.Strings(organizationsSlice)
+	organizations = strings.Join(organizationsSlice, ",")
+
+	h := sha1.New()
+	h.Write([]byte(organizations))
+	bs := h.Sum(nil)
+
+	return fmt.Sprintf("%x", bs)
 }

--- a/service/token/service.go
+++ b/service/token/service.go
@@ -155,7 +155,7 @@ func (s *service) DeleteOrgPolicy(clusterID string) error {
 	sysBackend := s.VaultClient.Sys()
 
 	// Delete the policy by name if it is created.
-	created, err := s.IsPolicyCreated(clusterID)
+	created, err := s.IsOrgPolicyCreated(clusterID)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/token/spec.go
+++ b/service/token/spec.go
@@ -24,6 +24,11 @@ type Service interface {
 	// certificates with respect to the given configuration.
 	Create(config CreateConfig) ([]string, error)
 
+	// CreateOrgPolicy creates a new policy to restrict access to only being able to
+	// issue signed certificates on the Vault PKI backend specific to the given
+	// cluster ID and organization.
+	CreateOrgPolicy(clusterID string) error
+
 	// CreatePolicy creates a new policy to restrict access to only being able to
 	// issue signed certificates on the Vault PKI backend specific to the given
 	// cluster ID. Here the given cluster ID is used to create the policy name and
@@ -32,11 +37,21 @@ type Service interface {
 	// to some Vault token.
 	CreatePolicy(clusterID string) error
 
+	// DeleteOrgPolicy removes an org policy from Vault using its name.
+	DeleteOrgPolicy(clusterID string) error
+
 	// DeletePolicy removes a policy from Vault using its name.
 	DeletePolicy(clusterID string) error
 
+	// IsOrgPolicyCreated checks whether the PKI org issue policy already exists.
+	IsOrgPolicyCreated(clusterID string) (bool, error)
+
 	// IsPolicyCreated checks whether the PKI issue policy already exists.
 	IsPolicyCreated(clusterID string) (bool, error)
+
+	// OrgPolicyName returns the name of an org policy used to restrict access to Vault
+	// for PKI issue requests. This policy is scoped to the given cluster ID.
+	OrgPolicyName(clusterID string) string
 
 	// PolicyName returns the name of a policy used to restrict access to Vault
 	// for PKI issue requests. This policy is scoped to the given cluster ID.

--- a/service/token/template.go
+++ b/service/token/template.go
@@ -14,6 +14,7 @@ type pkiIssuePolicyContext struct {
 // pkiIssueOrgPolicyContext is the template context provided to the rendering of
 // the pkiIssueOrgPolicyTemplate.
 type pkiIssueOrgPolicyContext struct {
+	ClusterID             string
 	OrganizationsRoleHash string
 }
 

--- a/service/token/template.go
+++ b/service/token/template.go
@@ -11,6 +11,12 @@ type pkiIssuePolicyContext struct {
 	ClusterID string
 }
 
+// pkiIssueOrgPolicyContext is the template context provided to the rendering of
+// the pkiIssueOrgPolicyTemplate.
+type pkiIssueOrgPolicyContext struct {
+	OrganizationsRoleHash string
+}
+
 // pkiIssuePolicyTemplate provides a template of Vault policies used to
 // restrict access to only being able to issue signed certificates specific to
 // a Vault PKI backend of a cluster ID.
@@ -20,6 +26,15 @@ var pkiIssuePolicyTemplate = `
 	}
 	path "pki-{{.ClusterID}}/roles/" {
 		capabilities = ["list"]
+	}
+`
+
+// pkiIssueOrgPolicyTemplate provides a template of Vault policy used to
+// restrict access to only being able to issue signed certificates specific to
+// a Vault PKI backend of a organization.
+var pkiIssueOrgPolicyTemplate = `
+	path "pki-{{.ClusterID}}/issue/role-org-{{.OrganizationsRoleHash}}" {
+		capabilities = ["create", "update", "delete"]
 	}
 `
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/certctl/issues/75#issuecomment-460966182
Basically, move this hack into certctl https://github.com/giantswarm/hive/pull/403/files
As it is used only within CP bootstrap, I'm doing this in a dumb way with duplicating explicitly policy methods